### PR TITLE
Fix: Backend venv stuff and locales

### DIFF
--- a/assets/requirements.txt
+++ b/assets/requirements.txt
@@ -1,1 +1,4 @@
 twitchpy==1.2.3
+loguru==0.7.2
+rpyc==6.0.0
+streamcontroller-plugin-tools>=2.0.0

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -1,6 +1,6 @@
 {
   "plugin.name": "Twitch",
-  "actions.base.status.no-credentials": "Missing credentials",
+  "actions.base.credentials.no-credentials": "Missing credentials",
   "actions.base.credentials.title": "Twitch Credentials",
   "actions.base.credentials.validate": "Validate",
   "actions.base.twitch_client_id": "Twitch Client ID",

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ class PluginTemplate(PluginBase):
 
         # Launch backend
         backend_path = os.path.join(self.PATH, "twitch_backend.py")
-        self.launch_backend(backend_path=backend_path, open_in_terminal=False)
+        self.launch_backend(backend_path=backend_path, open_in_terminal=False, venv_path=os.path.join(self.PATH, ".venv"))
         self.wait_for_backend(tries=5)
 
         settings = self.get_settings()


### PR DESCRIPTION
The environments for the backends always need `streamcontroller-plugin-tools` and `rpyc` in addition to the normal libraries. I think I forgot to mention that on the wiki...