### PR TITLE
[WIP] Fixing authentication callback to main page

### DIFF
--- a/TwitchActionBase.py
+++ b/TwitchActionBase.py
@@ -11,7 +11,7 @@ class TwitchActionBase(ActionBase):
     def get_config_rows(self) -> list:
         authed = self.plugin_base.backend.is_authed()
         if not authed:
-            label = "actions.base.status.no-credentials"
+            label = "actions.base.credentials.no-credentials"
             css_style = "twitch-controller-red"
         else:
             label = "actions.base.credentials.authenticated"
@@ -79,9 +79,10 @@ class TwitchActionBase(ActionBase):
                 "actions.base.credentials.no-credentials"), True)
             return
         self.plugin_base.backend.update_client_credentials(
-            client_id, client_secret)
+            client_id, client_secret, self.on_auth_completed)
 
     def _set_status(self, message: str, is_error: bool = False):
+        print(f'updating message: {message}')
         self.status_label.set_label(message)
         if is_error:
             self.status_label.remove_css_class("twitch-controller-green")
@@ -90,11 +91,11 @@ class TwitchActionBase(ActionBase):
             self.status_label.remove_css_class("twitch-controller-red")
             self.status_label.add_css_class("twitch-controller-green")
 
-    def on_auth_successful(self, client_id: str, client_secret: str, authorization_code: str) -> None:
-        settings = self.plugin_base.get_settings()
-        settings['client_id'] = client_id
-        settings['client_secret'] = client_secret
-        settings['authorization_code'] = authorization_code
-        self.plugin_base.set_settings(settings)
-        self._set_status(self.plugin_base.lm.get(
-            "actions.base.credentials.authenticated"), False)
+    def on_auth_completed(self, success: bool) -> None:
+        print(f'on_auth_completed: {success}')
+        if success:
+            self._set_status(self.plugin_base.lm.get(
+                "actions.base.credentials.authenticated"), False)
+        else:
+            self._set_status(self.plugin_base.lm.get(
+                "actions.base.credentials.failed"), True)

--- a/TwitchActionBase.py
+++ b/TwitchActionBase.py
@@ -78,11 +78,12 @@ class TwitchActionBase(ActionBase):
             self._set_status(self.plugin_base.lm.get(
                 "actions.base.credentials.no-credentials"), True)
             return
+        self.auth_button.set_sensitive(False)
+        self.plugin_base.auth_callback_fn = self.on_auth_completed
         self.plugin_base.backend.update_client_credentials(
-            client_id, client_secret, self.on_auth_completed)
+            client_id, client_secret)
 
     def _set_status(self, message: str, is_error: bool = False):
-        print(f'updating message: {message}')
         self.status_label.set_label(message)
         if is_error:
             self.status_label.remove_css_class("twitch-controller-green")
@@ -92,7 +93,7 @@ class TwitchActionBase(ActionBase):
             self.status_label.add_css_class("twitch-controller-green")
 
     def on_auth_completed(self, success: bool) -> None:
-        print(f'on_auth_completed: {success}')
+        self.auth_button.set_sensitive(True)
         if success:
             self._set_status(self.plugin_base.lm.get(
                 "actions.base.credentials.authenticated"), False)

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -6,6 +6,7 @@
   "actions.base.twitch_client_id": "Twitch Client ID",
   "actions.base.twitch_client_secret": "Twitch Client Secret",
   "actions.base.credentials.authenticated": "Authenticated successfully",
+  "actions.base.credentials.failed": "Authentication failed",
   "actions.message.message": "Message",
   "actions.chat_mode.mode_row.label": "Chat Mode",
   "actions.info.link.label": "Checkout how to configure this plugin on",

--- a/main.py
+++ b/main.py
@@ -20,9 +20,12 @@ class PluginTemplate(PluginBase):
         self.lm = self.locale_manager
         self.lm.set_to_os_default()
 
+        self.auth_callback_fn: callable = None
+
         # Launch backend
         backend_path = os.path.join(self.PATH, "twitch_backend.py")
-        self.launch_backend(backend_path=backend_path, open_in_terminal=False, venv_path=os.path.join(self.PATH, ".venv"))
+        self.launch_backend(backend_path=backend_path, open_in_terminal=False,
+                            venv_path=os.path.join(self.PATH, ".venv"))
         self.wait_for_backend(tries=5)
 
         settings = self.get_settings()
@@ -93,3 +96,7 @@ class PluginTemplate(PluginBase):
         settings['client_secret'] = client_secret
         settings['auth_code'] = auth_code
         self.set_settings(settings)
+
+    def on_auth_callback(self, success: bool) -> None:
+        if self.auth_callback_fn:
+            self.auth_callback_fn(success)

--- a/twitch_backend.py
+++ b/twitch_backend.py
@@ -120,7 +120,8 @@ class Backend(BackendBase):
         if not self.httpd_thread or not self.httpd_thread.is_alive():
             self.httpd_thread = threading.Thread(
                 target=self.httpd.serve_forever, daemon=True)
-        self.httpd_thread.start()
+        if not self.httpd_thread.is_alive():
+            self.httpd_thread.start()
 
         webbrowser.open(
             f'https://id.twitch.tv/oauth2/authorize?{encoded_params}')

--- a/twitch_backend.py
+++ b/twitch_backend.py
@@ -5,11 +5,12 @@ import webbrowser
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs, urlencode
 import threading
+import requests
 
 from streamcontroller_plugin_tools import BackendBase
 
 
-def make_handler(plugin_backend: 'Backend', client_id: str, client_secret: str):
+def make_handler(plugin_backend: 'Backend'):
     class AuthHandler(BaseHTTPRequestHandler):
         def do_GET(self):
             if not self.path.startswith('/auth'):
@@ -37,8 +38,8 @@ def make_handler(plugin_backend: 'Backend', client_id: str, client_secret: str):
                 plugin_backend.auth_failed()
                 return
 
-            plugin_backend.auth_with_code(
-                client_id, client_secret, query_params['code'][0])
+            plugin_backend.new_code(query_params['code'][0])
+
     return AuthHandler
 
 
@@ -48,9 +49,10 @@ class Backend(BackendBase):
         self.twitch: Client = None
         self.user_id: str = None
         self.token_path: str = None
+        self.client_secret: str = None
+        self.client_id: str = None
         self.httpd: HTTPServer = None
         self.httpd_thread: threading.Thread = None
-        self.auth_callback_fn: callable = None
 
     def set_token_path(self, path: str) -> None:
         self.token_path = path
@@ -89,7 +91,7 @@ class Backend(BackendBase):
 
     def get_chat_settings(self) -> dict:
         if not self.twitch:
-            return
+            return {}
         current = self.twitch.get_chat_settings(self.user_id, self.user_id)
         return {
             'subscriber_mode': current.subscriber_mode,
@@ -103,10 +105,11 @@ class Backend(BackendBase):
             return
         self.twitch.send_chat_message(self.user_id, self.user_id, message)
 
-    def update_client_credentials(self, client_id: str, client_secret: str, callbackfn: callable) -> None:
+    def update_client_credentials(self, client_id: str, client_secret: str) -> None:
         if None in (client_id, client_secret) or "" in (client_id, client_secret):
             return
-        self.auth_callback_fn = callbackfn
+        self.client_id = client_id
+        self.client_secret = client_secret
         params = {
             'client_id': client_id,
             'redirect_uri': 'http://localhost:3000/auth',
@@ -115,16 +118,25 @@ class Backend(BackendBase):
         }
         encoded_params = urlencode(params)
         if not self.httpd:
-            self.httpd = HTTPServer(('localhost', 3000), make_handler(
-                self, client_id, client_secret))
+            self.httpd = HTTPServer(('localhost', 3000), make_handler(self))
         if not self.httpd_thread or not self.httpd_thread.is_alive():
             self.httpd_thread = threading.Thread(
                 target=self.httpd.serve_forever, daemon=True)
         if not self.httpd_thread.is_alive():
             self.httpd_thread.start()
 
+        url = f'https://id.twitch.tv/oauth2/authorize?{encoded_params}'
+        check = requests.get(url, timeout=5)
+        if check.status_code != 200:
+            print('invalid client ID')
+            self.auth_failed()
+            return
+
         webbrowser.open(
             f'https://id.twitch.tv/oauth2/authorize?{encoded_params}')
+
+    def new_code(self, auth_code: str) -> None:
+        self.auth_with_code(self.client_id, self.client_secret, auth_code)
 
     def auth_with_code(self, client_id: str, client_secret: str, auth_code: str) -> None:
         try:
@@ -134,15 +146,14 @@ class Backend(BackendBase):
             self.user_id = users[0].user_id
             self.frontend.save_auth_settings(
                 client_id, client_secret, auth_code)
-            if self.auth_callback_fn:
-                print('auth callback')
-                self.auth_callback_fn(True)
-        except:
+            self.frontend.on_auth_callback(True)
+        except Exception as e:
+            print(e)
             self.auth_failed()
 
     def auth_failed(self) -> None:
-        if self.auth_callback_fn:
-            self.auth_callback_fn(False)
+        self.user_id = None
+        self.frontend.on_auth_callback(False)
 
     def is_authed(self) -> bool:
         return self.user_id != None


### PR DESCRIPTION
Currently, this doesn't work. The call from the backend to `self.auth_callback_fn()` which points to the callback configured in the frontend, never processes until the app quits. Checking the logs, once the app begins shutting down, the log messages in the frontend start showing up.