### PR TITLE
feat(actions): add Shoutout action

### DIFF
--- a/actions/Shoutout.py
+++ b/actions/Shoutout.py
@@ -1,0 +1,62 @@
+from enum import StrEnum
+from typing import Any, List
+
+from .TwitchCore import TwitchCore
+from src.backend.PluginManager.EventAssigner import EventAssigner
+from src.backend.PluginManager.InputBases import Input
+
+from GtkHelper.GenerativeUI.EntryRow import EntryRow
+
+from loguru import logger as log
+
+from ..constants import ERROR_DISPLAY_DURATION_SECONDS
+
+
+class Icons(StrEnum):
+    CHAT = "chat"
+
+
+class Shoutout(TwitchCore):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.icon_keys = [Icons.CHAT]
+        self.current_icon = self.get_icon(Icons.CHAT)
+        self.icon_name = Icons.CHAT
+        self.has_configuration = True
+
+    def create_event_assigners(self) -> None:
+        self.event_manager.add_event_assigner(
+            EventAssigner(
+                id="shoutout",
+                ui_label="Shoutout",
+                default_event=Input.Key.Events.DOWN,
+                callback=self._on_shoutout,
+            )
+        )
+
+    def create_generative_ui(self) -> None:
+        self.username_row = EntryRow(
+            action_core=self,
+            var_name="shoutout.username",
+            default_value="",
+            title="shoutout-username",
+            auto_add=False,
+            complex_var_name=True,
+        )
+
+    def get_config_rows(self) -> List[Any]:
+        return [self.username_row.widget]
+
+    def _on_shoutout(self, _: Any) -> None:
+        username = self.username_row.get_value()
+
+        if not username or username.strip() == "":
+            log.error("No username configured for shoutout")
+            self.show_error(ERROR_DISPLAY_DURATION_SECONDS)
+            return
+
+        try:
+            self.backend.send_shoutout(username)
+        except Exception as ex:
+            log.error(f"Failed to send shoutout to '{username}': {ex}")
+            self.show_error(ERROR_DISPLAY_DURATION_SECONDS)

--- a/locales.csv
+++ b/locales.csv
@@ -5,6 +5,7 @@ ad-snooze-subtitle;Snoozes ad for 5 minutes when pushed
 chat-channel-id;Twitch Channel to send message to
 chat-message-text;Text to send
 chat-toggle-dropdown;Chat Mode
+shoutout-username;Username to Shout Out
 ;;
 actions.base.credentials.authenticated;Authenticated successfully
 actions.base.credentials.failed;Authenication failed

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from .actions.Marker import Marker
 from .actions.ChatMode import ChatMode
 from .actions.PlayAd import PlayAd
 from .actions.AdSchedule import AdSchedule
+from .actions.Shoutout import Shoutout
 
 
 class PluginTemplate(PluginBase):
@@ -29,7 +30,7 @@ class PluginTemplate(PluginBase):
 
     Provides integration with Twitch for StreamController, enabling actions like:
     - Creating clips and stream markers
-    - Sending chat messages
+    - Sending chat messages and shoutouts
     - Displaying viewer counts
     - Managing chat modes (follower-only, emote-only, slow mode, etc.)
     - Playing ads and managing ad schedules
@@ -150,6 +151,19 @@ class PluginTemplate(PluginBase):
             },
         )
         self.add_action_holder(self.ad_schedule_action_holder)
+
+        self.shoutout_action_holder = ActionHolder(
+            plugin_base=self,
+            action_base=Shoutout,
+            action_id_suffix="Shoutout",
+            action_name="Shoutout",
+            action_support={
+                Input.Key: ActionInputSupport.SUPPORTED,
+                Input.Dial: ActionInputSupport.UNTESTED,
+                Input.Touchscreen: ActionInputSupport.UNTESTED,
+            },
+        )
+        self.add_action_holder(self.shoutout_action_holder)
 
     def _setup_backend(self) -> bool:
         backend_path = os.path.join(self.PATH, "twitch_backend.py")

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
+  "version": "1.8.0",
   "thumbnail": "store/thumbnail.png",
   "id": "com_imdevinc_StreamControllerTwitchPlugin",
   "name": "Twitch Integration",

--- a/twitch_backend.py
+++ b/twitch_backend.py
@@ -303,6 +303,34 @@ class Backend(BackendBase):
         schedule = _get_ad_schedule()
         return schedule.next_ad_at, schedule.snooze_count
 
+    def send_shoutout(self, target_username: str) -> None:
+        """Send a shoutout to the specified user.
+
+        Args:
+            target_username: The username of the broadcaster to shout out
+
+        Raises:
+            Exception: If the user is not found or the shoutout fails
+        """
+        if not self.twitch:
+            raise Exception("Not authenticated")
+        self.validate_auth()
+
+        # Resolve username to user ID
+        target_id = self.get_channel_id(target_username)
+        if not target_id:
+            raise Exception(f"User '{target_username}' not found")
+
+        @self.rate_limiter
+        def _send_shoutout() -> None:
+            return self.twitch.send_a_shoutout(
+                from_broadcaster_id=self.user_id,
+                to_broadcaster_id=target_id,
+                moderator_id=self.user_id,
+            )
+
+        _send_shoutout()
+
     def update_client_credentials(self, client_id: str, client_secret: str) -> None:
         if None in (client_id, client_secret) or "" in (client_id, client_secret):
             return
@@ -312,7 +340,7 @@ class Backend(BackendBase):
             "client_id": client_id,
             "redirect_uri": OAUTH_REDIRECT_URI,
             "response_type": "code",
-            "scope": "user:write:chat channel:manage:broadcast moderator:manage:chat_settings clips:edit channel:read:subscriptions channel:edit:commercial channel:manage:ads channel:read:ads",
+            "scope": "user:write:chat channel:manage:broadcast moderator:manage:chat_settings clips:edit channel:read:subscriptions channel:edit:commercial channel:manage:ads channel:read:ads moderator:manage:shoutouts",
         }
         encoded_params = urlencode(params)
 


### PR DESCRIPTION
## Summary
- Adds new Shoutout action allowing streamers to shout out other
  channels directly from StreamController
- Implements backend API integration with Twitch shoutout endpoint
- Adds required OAuth scope (moderator:manage:shoutouts)
- Bumps plugin version to 1.8.0

## Changes
- **actions/Shoutout.py**: New action with username input field
- **twitch_backend.py**: Added send_shoutout() method with user
  lookup and rate limiting
- **main.py**: Registered Shoutout action holder
- **locales.csv**: Added shoutout-username locale string
- **manifest.json**: Version bump to 1.8.0

## Testing
Users will need to re-authenticate after this update to grant the
new shoutout permission.

__Disclosure__
This change was developed with the assistance of AI, but was
reviewed and tested by a human.